### PR TITLE
Use latest version of envoy-pilot

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
 ## XDS Server
   xds-server:
-    image: tak2siva/envoy-pilot:v0.1.83
+    image: tak2siva/envoy-pilot:v0.2.7
     restart: on-failure
     networks:
       - xds-example


### PR DESCRIPTION
I was facing some error with old version. Spend some time to understand the error. It is fixed in latest version. So updating it.